### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/ostap/fitting/signals.py
+++ b/ostap/fitting/signals.py
@@ -1305,7 +1305,7 @@ models.append ( SkewGauss_pdf )
 #  - for rho_{l,r}=0 left/right tails are exponential.
 #  - for large asymmetry parameter function has weird shape
 #
-#  @see http://dx.doi.org/10.1007/JHEP06(2012)141     
+#  @see https://doi.org/10.1007/JHEP06(2012)141     
 #  @see Ostap::Math::Bukin
 #  @see Analusis::Models::Bukin
 #  @author Vanya BELYAEV Ivan.Belyaeve@itep.ru
@@ -1316,7 +1316,7 @@ class Bukin_pdf(MASS) :
     - exponential (optionally gaussian) asymmetrical tails
     see http://journals.aps.org/prd/abstract/10.1103/PhysRevD.84.112007
     see http://arxiv.org/abs/1107.5751
-    see http://dx.doi.org/10.1007/JHEP06(2012)141     
+    see https://doi.org/10.1007/JHEP06(2012)141     
     Here small reparameterization is applied to achieve more stable fits.
     
     It is very well suitable to describe high statistic charm meson peaks,
@@ -2637,7 +2637,7 @@ models.append ( Voigt_pdf )
 #       "Extended pseudo-Voigt function for approximating the Voigt profile"
 #       J. Appl. Cryst. (2000). 33, 1311-1316
 #  @see doi:10.1107/S0021889800010219
-#  @see http://dx.doi.org/10.1107/S0021889800010219
+#  @see https://doi.org/10.1107/S0021889800010219
 #  @author Vanya BELYAEV Ivan.Belyaev@itep.ru
 #  @date 2016-06-15
 class PseudoVoigt_pdf(Voigt_pdf) :
@@ -2649,7 +2649,7 @@ class PseudoVoigt_pdf(Voigt_pdf) :
     ``Extended pseudo-Voigt function for approximating the Voigt profile''
     J. Appl. Cryst. (2000). 33, 1311-1316
     - see doi:10.1107/S0021889800010219
-    - see http://dx.doi.org/10.1107/S0021889800010219
+    - see https://doi.org/10.1107/S0021889800010219
     
     Parameters
     - mean  : location 
@@ -3467,7 +3467,7 @@ models.append ( LASS_pdf )
 # =============================================================================
 ## @class Bugg_pdf
 #  The parameterization of sigma pole by B.S.Zou and D.V.Bugg, Phys.Rev. D48 (1993) R3948.
-#  @see http://dx.doi.org/10.1103/PhysRevD.48.R3948
+#  @see https://doi.org/10.1103/PhysRevD.48.R3948
 #  @see Ostap::Models::Bugg
 #  @see Ostap::Math::Bugg
 #  @author Vanya BELYAEV Ivan.Belyaev@itep.ru
@@ -3475,7 +3475,7 @@ models.append ( LASS_pdf )
 class Bugg_pdf(MASS) :
     """ The parameterization of sigma pole by
     B.S.Zou and D.V.Bugg, Phys.Rev. D48 (1993) R3948.
-    http://dx.doi.org/10.1103/PhysRevD.48.R3948
+    https://doi.org/10.1103/PhysRevD.48.R3948
     """
     def __init__ ( self           ,
                    name           ,

--- a/ostap/histos/graphs.py
+++ b/ostap/histos/graphs.py
@@ -2632,7 +2632,7 @@ ROOT.TMultiGraph.T         = _grae_transpose_
 #  >>> spline = histo.(p,i,d)spline( .... )
 #  >>> graph  = histo.lw_graph ( spline[2] ) 
 #  @endcode 
-#  @see http://dx.doi.org/10.1016/0168-9002(94)01112-5
+#  @see https://doi.org/10.1016/0168-9002(94)01112-5
 #  @author  Vanya BELYAEV  Ivan.Belyaev@itep.ru
 #  @date    2014-12-08
 def _lw_graph_ ( histo , func ) :
@@ -2744,7 +2744,7 @@ ROOT.TH1F.lw_graph = _lw_graph_
 #  >>> spline = histo.(p,i,d)spline( .... )
 #  >>> graph  = lw_graph ( histo ,  spline[2] ) 
 #  @endcode 
-#  @see http://dx.doi.org/10.1016/0168-9002(94)01112-5
+#  @see https://doi.org/10.1016/0168-9002(94)01112-5
 #  @author  Vanya BELYAEV  Ivan.Belyaev@itep.ru
 #  @date    2014-12-08
 def lw_graph ( histo , func ) :

--- a/source/include/Ostap/BSpline.h
+++ b/source/include/Ostap/BSpline.h
@@ -1498,7 +1498,7 @@ namespace Ostap
      *  Boehm's algorithm is used 
      *  @see W.Boehm, ``Inserting new knots into B-spline curves'',
      *       Computer-Aided Design, 12, no.4, (1980) 199 
-     *  @see http://dx.doi.org/10.1016/0010-4485(80)90154-2
+     *  @see https://doi.org/10.1016/0010-4485(80)90154-2
      *  @see http://www.sciencedirect.com/science/article/pii/0010448580901542
      *  @param x     (INPUT)  position of new knot 
      *  @param knots (UPDATE) vector of knots 

--- a/source/include/Ostap/Bernstein.h
+++ b/source/include/Ostap/Bernstein.h
@@ -21,7 +21,7 @@
  *  @see http://en.wikipedia.org/wiki/Bernstein_polynomial
  *  @see  Rida Farouki, ``The Bernstein polynomial basis: A centennial retrospective'', 
  *        Computer Aided Geometric Design, 29 (2012) 379. 
- *  @see http://dx.doi.org/10.1016/j.cagd.2012.03.001
+ *  @see https://doi.org/10.1016/j.cagd.2012.03.001
  *  @author Vanya BELYAEV Ivan.Belyaev@itep.ru
  *  @date 2010-04-19
  */

--- a/source/include/Ostap/BreitWigner.h
+++ b/source/include/Ostap/BreitWigner.h
@@ -893,7 +893,7 @@ namespace Ostap
      *       "Extended pseudo-Voigt function for approximating the Voigt profile"
      *       J. Appl. Cryst. (2000). 33, 1311-1316
      *  @see doi:10.1107/S0021889800010219
-     *  @see http://dx.doi.org/10.1107/S0021889800010219
+     *  @see https://doi.org/10.1107/S0021889800010219
      *  @author Vanya BELYAEV Ivan.Belyaev@itep.ru
      *  @date 2016-06-13
      */

--- a/source/include/Ostap/MoreMath.h
+++ b/source/include/Ostap/MoreMath.h
@@ -400,7 +400,7 @@ namespace Ostap
      *  where \f$ R_D(x,y,z)\f$ is a symmetric Carlson form 
      *  @see Carlson, B.C., "Numerical computation of real or complex elliptic integrals", 
      *                Numerical Algorithms, 10, 1995,  13
-     *  @see http://dx.doi.org/10.1007/BF02198293
+     *  @see https://doi.org/10.1007/BF02198293
      *  @see https://arxiv.org/abs/math/9409227
      */
     double elliptic_KmE ( const double k   ) ;    
@@ -420,7 +420,7 @@ namespace Ostap
      *  @see https://en.wikipedia.org/wiki/Elliptic_integral
      *  @see Carlson, B.C., "Numerical computation of real or complex elliptic integrals", 
      *                Numerical Algorithms, 10, 1995,  13
-     *  @see http://dx.doi.org/10.1007/BF02198293
+     *  @see https://doi.org/10.1007/BF02198293
      *  @see https://arxiv.org/abs/math/9409227
      */
     double elliptic_KZ ( const double beta  , const double k   ) ;

--- a/source/include/Ostap/PDFs.h
+++ b/source/include/Ostap/PDFs.h
@@ -1833,7 +1833,7 @@ namespace Ostap
     /** @class Bukin
      *  "Bukin"-function, aka "Modified Novosibirsk function"
      *  @see http://arxiv.org/abs/1107.5751
-     *  @see http://dx.doi.org/10.1007/JHEP06(2012)141
+     *  @see https://doi.org/10.1007/JHEP06(2012)141
      *  @see Ostap::Math::Bukin
      *  @author Vanya BELYAEV Ivan.BElyaev@itep.ru
      *  @date 2011-12-05

--- a/source/include/Ostap/Peaks.h
+++ b/source/include/Ostap/Peaks.h
@@ -562,7 +562,7 @@ namespace Ostap
      *  for description of asymmetric peaks with the exponential tails
      *
      *  @see http://arxiv.org/abs/1107.5751
-     *  @see http://dx.doi.org/10.1007/JHEP06(2012)141
+     *  @see https://doi.org/10.1007/JHEP06(2012)141
      *  @date 2011-04-19
      */
     class  Bukin 

--- a/source/src/BSpline.cpp
+++ b/source/src/BSpline.cpp
@@ -1010,7 +1010,7 @@ double Ostap::Math::deboor
  *  Boehm's algorithm is used 
  *  @see W.Boehm, ``Inserting new knots into B-spline curves'',
  *       Computer-Aided Design, 12, no.4, (1980) 199 
- *  @see http://dx.doi.org/10.1016/0010-4485(80)90154-2
+ *  @see https://doi.org/10.1016/0010-4485(80)90154-2
  *  @see http://www.sciencedirect.com/science/article/pii/0010448580901542
  *  @param x     (INPUT)  position of new knot 
  *  @param knots (UPDATE) vector of knots 

--- a/source/src/BreitWigner.cpp
+++ b/source/src/BreitWigner.cpp
@@ -2310,7 +2310,7 @@ double Ostap::Math::Voigt::fwhm   () const
 // "Extended pseudo-Voigt function for approximating the Voigt profile"
 // J. Appl. Cryst. (2000). 33, 1311-1316
 // doi:10.1107/S0021889800010219
-// http://dx.doi.org/10.1107/S0021889800010219
+// https://doi.org/10.1107/S0021889800010219
 // ============================================================================
 // constructor  from all parameters
 // ============================================================================

--- a/source/src/MoreMath.cpp
+++ b/source/src/MoreMath.cpp
@@ -1173,7 +1173,7 @@ double Ostap::Math::elliptic_Z ( const double beta  , const double k   )
  *  @see https://en.wikipedia.org/wiki/Elliptic_integral
  *  @see Carlson, B.C., "Numerical computation of real or complex elliptic integrals", 
  *                Numerical Algorithms, 10, 1995,  13
- *  @see http://dx.doi.org/10.1007/BF02198293
+ *  @see https://doi.org/10.1007/BF02198293
  *  @see https://arxiv.org/abs/math/9409227
  */
 // ============================================================================
@@ -1206,7 +1206,7 @@ double Ostap::Math::elliptic_KZ ( const double beta  , const double k   )
  *  where \f$ R_D(x,y,z)\f$ is a symmetric Carlson form 
  *  @see Carlson, B.C., "Numerical computation of real or complex elliptic integrals", 
  *                Numerical Algorithms, 10, 1995,  13
- *  @see http://dx.doi.org/10.1007/BF02198293
+ *  @see https://doi.org/10.1007/BF02198293
  *  @see https://arxiv.org/abs/math/9409227
  */
 // ============================================================================


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!