### PR TITLE
Changing the master and slave language

### DIFF
--- a/ostap/io/sqlitedict.py
+++ b/ostap/io/sqlitedict.py
@@ -313,7 +313,7 @@ class SqliteDict(DictClass):
 
     def tables ( self ) :
         """ get list of tables in DBASE"""
-        GET_TABLES = "SELECT name FROM sqlite_master WHERE type='table';"
+        GET_TABLES = "SELECT name FROM sqlite_main WHERE type='table';"
         tables = [] 
         for table in self.conn.select ( GET_TABLES ) :
             tables.append ( table  ) 
@@ -405,7 +405,7 @@ class SqliteDict(DictClass):
         """get the names of the tables in an sqlite db as a list"""
         if not os.path.isfile(filename):
             raise IOError('file %s does not exist' % (filename))
-        GET_TABLENAMES = 'SELECT name FROM sqlite_master WHERE type="table"'
+        GET_TABLENAMES = 'SELECT name FROM sqlite_main WHERE type="table"'
         
         #with sqlite3.connect(filename) as conn:
         #    cursor = conn.execute(GET_TABLENAMES)

--- a/ostap/parallel/task.py
+++ b/ostap/parallel/task.py
@@ -95,29 +95,29 @@ class Task ( object ) :
         
         return obj
 
-    ## Local initialization:  invoked once on localhost for master task
+    ## Local initialization:  invoked once on localhost for main task
     def initialize_local  ( self )          :
-        """Local initialization:  invoked once on localhost for master task"""
+        """Local initialization:  invoked once on localhost for main task"""
         pass
     
-    ## Remote initialization: invoked for each slave task on remote host
+    ## Remote initialization: invoked for each subordinate task on remote host
     def initialize_remote ( self , jobid = -1 )  :
-        """Remote initialization: invoked for each slave task on remote host
+        """Remote initialization: invoked for each subordinate task on remote host
         - default: run ``local initialization''
         """
         return self.initialize_local () 
     
-    ## Finalization action: invoked once on local host for the master task (after merge)
+    ## Finalization action: invoked once on local host for the main task (after merge)
     def finalize          ( self )          :
-        """Finalization action: invoked once on local host for the master task (after merge)"""
+        """Finalization action: invoked once on local host for the main task (after merge)"""
         pass
     
-    ## Process the (slave) task on remote host
+    ## Process the (subordinate) task on remote host
     #  @attention must return the result
     #  @param jobid jobid 
     @abc.abstractmethod 
     def process           ( self , jobid , *params ) :
-        """Process the (slave) task on remote host
+        """Process the (subordinate) task on remote host
         - It must return the results!
         """
         return None 

--- a/ostap/tools/chopping.py
+++ b/ostap/tools/chopping.py
@@ -5,7 +5,7 @@
 #  ``TMVA Chopper'' - helper utility to train/use  TMVA using ``chopping''
 #
 # ``Chopping'' is a jargon name for k-fold cross-validation technique
-# @see https://machinelearningmastery.com/k-fold-cross-validation
+# @see https://machinelearningmainy.com/k-fold-cross-validation
 # 
 # The most frequest case:
 # - TMVA is trained using the simulated events as ``Signal'' and realtively
@@ -41,7 +41,7 @@
 """``TMVAChopper'' - helper utility to train/use  TMVA using ``chopping''
 
 ``Chopping'' is a jargon name for k-fold cross-validation technique.
- - see e.g. https://machinelearningmastery.com/k-fold-cross-validation
+ - see e.g. https://machinelearningmainy.com/k-fold-cross-validation
 
 Most frequest case:
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.