### PR TITLE
Fix bug when seeking dataset entries within limits

### DIFF
--- a/ostap/fitting/pdfbasic.py
+++ b/ostap/fitting/pdfbasic.py
@@ -2491,8 +2491,11 @@ class APDF1 ( Components ) :
             vd_minmax = vd.minmax()
             if not vd_minmax : continue
 
-            vcut1 = ROOT.TCut ( '%s<%.17g'  % ( vd.name      , vd_minmax[0] ) )
-            vcut2 = ROOT.TCut ( '%.17g<=%s' % ( vd_minmax[1] , vd.name      ) )
+            v_min = max(vv_minmax[0], vd_minmax[0])
+            v_max = min(vv_minmax[1], vd_minmax[1])
+
+            vcut1 = ROOT.TCut ( '%s<%.17g'  % ( vd.name      , v_min ) )
+            vcut2 = ROOT.TCut ( '%.17g<=%s' % ( v_max , vd.name      ) )
             if   cuts : cuts  = cuts | ( vcut1 | vcut2 )
             else      : cuts  =          vcut1 | vcut2 
 


### PR DESCRIPTION
Use the smallest limits of the variable by itself and inside the dataset. The limits in the dataset may sometimes be infinite, which creates syntactically incorrect cut expressions. Ignoring the limits of the variable by itself is also conceptually incorrect.